### PR TITLE
[#4] 인터뷰 게시글, 리스트 조회 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.6.3'
+    id 'org.springframework.boot' version '2.6.2'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
 }

--- a/src/main/java/com/seoridam/rehearserver/controller/InterviewController.java
+++ b/src/main/java/com/seoridam/rehearserver/controller/InterviewController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.seoridam.rehearserver.dto.InterviewListDto;
+import com.seoridam.rehearserver.dto.InterviewListSource;
 import com.seoridam.rehearserver.dto.InterviewResponseDto;
 import com.seoridam.rehearserver.global.common.StatusEnum;
 import com.seoridam.rehearserver.global.common.SuccessResponse;
@@ -39,7 +40,7 @@ public class InterviewController {
 	public SuccessResponse getInterviewList(@RequestParam("page") Integer page, @RequestParam("size") Integer size){
 
 		PageRequest pageRequest = PageRequest.of(page,size);
-		Page<InterviewListDto> interviewList = interviewService.getInterviewList(pageRequest);
+		Page<InterviewListSource> interviewList = interviewService.getInterviewList(pageRequest);
 
 		return SuccessResponse.builder()
 			.status(StatusEnum.OK)

--- a/src/main/java/com/seoridam/rehearserver/controller/InterviewController.java
+++ b/src/main/java/com/seoridam/rehearserver/controller/InterviewController.java
@@ -1,0 +1,51 @@
+package com.seoridam.rehearserver.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.seoridam.rehearserver.dto.InterviewListDto;
+import com.seoridam.rehearserver.dto.InterviewResponseDto;
+import com.seoridam.rehearserver.global.common.StatusEnum;
+import com.seoridam.rehearserver.global.common.SuccessResponse;
+import com.seoridam.rehearserver.service.InterviewService;
+
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class InterviewController {
+
+	public final InterviewService interviewService;
+
+	@GetMapping("/interview/{id}")
+	public SuccessResponse getInterview(@PathVariable Long id){
+
+		InterviewResponseDto interview = interviewService.getInterview(id);
+
+		return SuccessResponse.builder()
+			.status(StatusEnum.OK)
+			.data(interview)
+			.message("인터뷰 조회 성공")
+			.build();
+	}
+
+	@GetMapping("/interview/list")
+	@ApiOperation(value = "내용을 제외한 인터뷰 리스트 목록 반환", notes = "ex: http://localhost:8080/interview/list/?page=3&size=4")
+	public SuccessResponse getInterviewList(@RequestParam("page") Integer page, @RequestParam("size") Integer size){
+
+		PageRequest pageRequest = PageRequest.of(page,size);
+		Page<InterviewListDto> interviewList = interviewService.getInterviewList(pageRequest);
+
+		return SuccessResponse.builder()
+			.status(StatusEnum.OK)
+			.data(interviewList)
+			.message("인터뷰 조회 성공")
+			.build();
+	}
+
+}

--- a/src/main/java/com/seoridam/rehearserver/domain/Category.java
+++ b/src/main/java/com/seoridam/rehearserver/domain/Category.java
@@ -1,0 +1,28 @@
+package com.seoridam.rehearserver.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+public class Category {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "CATEGORY_ID")
+	private Long id;
+
+	private String name;
+
+	protected Category() {}
+
+}

--- a/src/main/java/com/seoridam/rehearserver/domain/Interview.java
+++ b/src/main/java/com/seoridam/rehearserver/domain/Interview.java
@@ -30,16 +30,16 @@ public class Interview {
 	@Builder.Default
 	private LocalDate createDate = LocalDate.now();
 	private Integer view;
-	private String video_url;
-	private String photo_url;
+	private String videoUrl;
+	private String photoUrl;
 	private String title;
 	//소제목
-	private String sub_title;
+	private String subTitle;
 	//클릭 전 소개문
-	private String intro_text;
+	private String introText;
 	//본문
 	@Column(columnDefinition = "TEXT")
-	private String body_text;
+	private String bodyText;
 
 	//연관관계 매핑 ===================
 

--- a/src/main/java/com/seoridam/rehearserver/domain/Interview.java
+++ b/src/main/java/com/seoridam/rehearserver/domain/Interview.java
@@ -1,0 +1,52 @@
+package com.seoridam.rehearserver.domain;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+public class Interview {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "INTERVIEW_ID")
+	private Long id;
+
+	@Builder.Default
+	private LocalDate createDate = LocalDate.now();
+	private Integer view;
+	private String video_url;
+	private String photo_url;
+	private String title;
+	//소제목
+	private String sub_title;
+	//클릭 전 소개문
+	private String intro_text;
+	//본문
+	@Column(columnDefinition = "TEXT")
+	private String body_text;
+
+	//연관관계 매핑 ===================
+
+	@JsonIgnore //무한루프 방지
+	@OneToMany(mappedBy = "interview")
+	private List<Tag> tagList;
+
+	protected Interview(){}
+
+}

--- a/src/main/java/com/seoridam/rehearserver/domain/SubCategory.java
+++ b/src/main/java/com/seoridam/rehearserver/domain/SubCategory.java
@@ -1,0 +1,41 @@
+package com.seoridam.rehearserver.domain;
+
+import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class SubCategory {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "SUBCATEGORY_ID")
+	private Long id;
+
+	private String name;
+
+	//연관관계 매핑 ===================
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "CATEGORY_ID")
+	private Category category;
+
+	protected SubCategory() {}
+
+	@Builder
+	public SubCategory(String name){
+		this.name=name;
+	}
+
+}

--- a/src/main/java/com/seoridam/rehearserver/domain/Tag.java
+++ b/src/main/java/com/seoridam/rehearserver/domain/Tag.java
@@ -1,0 +1,39 @@
+package com.seoridam.rehearserver.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class Tag {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "TAG_ID")
+	private Long id;
+
+	//연관관계 매핑 ===================
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "INTERVIEW_ID")
+	private Interview interview;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "SUBCATEGORY_ID")
+	private SubCategory subCategory;
+
+	protected Tag(){}
+}

--- a/src/main/java/com/seoridam/rehearserver/dto/InterviewListDto.java
+++ b/src/main/java/com/seoridam/rehearserver/dto/InterviewListDto.java
@@ -1,0 +1,26 @@
+package com.seoridam.rehearserver.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.seoridam.rehearserver.domain.Tag;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class InterviewListDto {
+	private Long id;
+	private LocalDate createDate;
+	private Integer view;
+	private String photo_url;
+	private String title;
+	private String intro_text;
+	private List<String> subcategory_names;
+
+	protected InterviewListDto(){}
+
+}

--- a/src/main/java/com/seoridam/rehearserver/dto/InterviewListDto.java
+++ b/src/main/java/com/seoridam/rehearserver/dto/InterviewListDto.java
@@ -3,8 +3,6 @@ package com.seoridam.rehearserver.dto;
 import java.time.LocalDate;
 import java.util.List;
 
-import com.seoridam.rehearserver.domain.Tag;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,10 +14,10 @@ public class InterviewListDto {
 	private Long id;
 	private LocalDate createDate;
 	private Integer view;
-	private String photo_url;
+	private String photoUrl;
 	private String title;
-	private String intro_text;
-	private List<String> subcategory_names;
+	private String introText;
+	private List<String> subcategoryNames;
 
 	protected InterviewListDto(){}
 

--- a/src/main/java/com/seoridam/rehearserver/dto/InterviewListSource.java
+++ b/src/main/java/com/seoridam/rehearserver/dto/InterviewListSource.java
@@ -1,0 +1,20 @@
+package com.seoridam.rehearserver.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.seoridam.rehearserver.domain.SubCategory;
+
+public interface InterviewListSource {
+	Long getId();
+	LocalDate getCreateDate();
+	Integer getView();
+	String getPhotoUrl();
+	String getTitle();
+	String getIntroText();
+	List<TagInfo> getTagList();
+
+	interface TagInfo{
+		SubCategory getSubCategory();
+	}
+}

--- a/src/main/java/com/seoridam/rehearserver/dto/InterviewResponseDto.java
+++ b/src/main/java/com/seoridam/rehearserver/dto/InterviewResponseDto.java
@@ -11,7 +11,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class InterviewResponseDto {
-	private Long id;
 	private LocalDate createDate;
 	private Integer view;
 	private String video_url;

--- a/src/main/java/com/seoridam/rehearserver/dto/InterviewResponseDto.java
+++ b/src/main/java/com/seoridam/rehearserver/dto/InterviewResponseDto.java
@@ -1,0 +1,27 @@
+package com.seoridam.rehearserver.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class InterviewResponseDto {
+	private Long id;
+	private LocalDate createDate;
+	private Integer view;
+	private String video_url;
+	private String photo_url;
+	private String title;
+	private String intro_text;
+	private String body_text;
+	private String sub_title;
+	private List<String> subcategory_names;
+
+	protected InterviewResponseDto(){}
+
+}

--- a/src/main/java/com/seoridam/rehearserver/repository/InterviewRepository.java
+++ b/src/main/java/com/seoridam/rehearserver/repository/InterviewRepository.java
@@ -1,0 +1,22 @@
+package com.seoridam.rehearserver.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.seoridam.rehearserver.domain.Interview;
+
+public interface InterviewRepository extends JpaRepository<Interview, Long> {
+
+	//인터뷰 조회
+	@Override
+	Optional<Interview> findById(Long id);
+
+	// 인터뷰 목록 페이지별 조회
+	// 추후 성능 개선 필요
+	@Override
+	Page<Interview> findAll(Pageable pageable);
+
+}

--- a/src/main/java/com/seoridam/rehearserver/repository/InterviewRepository.java
+++ b/src/main/java/com/seoridam/rehearserver/repository/InterviewRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.seoridam.rehearserver.domain.Interview;
+import com.seoridam.rehearserver.dto.InterviewListSource;
 
 public interface InterviewRepository extends JpaRepository<Interview, Long> {
 
@@ -14,9 +15,7 @@ public interface InterviewRepository extends JpaRepository<Interview, Long> {
 	@Override
 	Optional<Interview> findById(Long id);
 
-	// 인터뷰 목록 페이지별 조회
-	// 추후 성능 개선 필요
-	@Override
-	Page<Interview> findAll(Pageable pageable);
-
+	//find 와 by는 무조건 써줘야 함
+	//id 'org.springframework.boot' version '2.6.2' 이하로만 작동
+	Page<InterviewListSource> findInterviewProjectionsBy(Pageable pageable);
 }

--- a/src/main/java/com/seoridam/rehearserver/service/InterviewService.java
+++ b/src/main/java/com/seoridam/rehearserver/service/InterviewService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.seoridam.rehearserver.domain.Interview;
 import com.seoridam.rehearserver.domain.Tag;
 import com.seoridam.rehearserver.dto.InterviewListDto;
+import com.seoridam.rehearserver.dto.InterviewListSource;
 import com.seoridam.rehearserver.dto.InterviewResponseDto;
 import com.seoridam.rehearserver.repository.InterviewRepository;
 
@@ -37,39 +38,19 @@ public class InterviewService {
 		return InterviewResponseDto.builder()
 			.id(interview.getId())
 			.createDate(interview.getCreateDate())
-			.body_text(interview.getBody_text())
-			.intro_text(interview.getIntro_text())
-			.sub_title(interview.getSub_title())
-			.photo_url(interview.getPhoto_url())
+			.body_text(interview.getBodyText())
+			.intro_text(interview.getIntroText())
+			.sub_title(interview.getSubTitle())
+			.photo_url(interview.getPhotoUrl())
 			.subcategory_names(subcategory_names)
 			.view(interview.getView())
-			.video_url(interview.getVideo_url())
+			.video_url(interview.getVideoUrl())
 			.title(interview.getTitle()).build();
 	}
 
 	//인터뷰 리스트 목록 조회
 	@Transactional(readOnly = true)
-	public Page<InterviewListDto> getInterviewList(PageRequest pageRequest){
-		Page<Interview> interviewList = interviewRepository.findAll(pageRequest);
-
-		List<InterviewListDto> interviewListDtos =
-			interviewList.stream().map(interview -> {
-				//태그 이름만 모아서 리스트 생성
-				List<Tag> tagList = interview.getTagList();
-				List<String> subcategory_names = tagList.stream().map(tag -> tag.getSubCategory().getName()).collect(Collectors.toList());
-				//DTO 반환
-				return InterviewListDto.builder()
-					.id(interview.getId())
-					.createDate(interview.getCreateDate())
-					.title(interview.getTitle())
-					.intro_text(interview.getIntro_text())
-					.photo_url(interview.getPhoto_url())
-					.view(interview.getView())
-					.subcategory_names(subcategory_names)
-					.build();
-			}).collect(Collectors.toList());
-
-		return new PageImpl<>(interviewListDtos);
+	public Page<InterviewListSource> getInterviewList(PageRequest pageRequest){
+		return interviewRepository.findInterviewProjectionsBy(pageRequest);
 	}
-
 }

--- a/src/main/java/com/seoridam/rehearserver/service/InterviewService.java
+++ b/src/main/java/com/seoridam/rehearserver/service/InterviewService.java
@@ -1,0 +1,75 @@
+package com.seoridam.rehearserver.service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.seoridam.rehearserver.domain.Interview;
+import com.seoridam.rehearserver.domain.Tag;
+import com.seoridam.rehearserver.dto.InterviewListDto;
+import com.seoridam.rehearserver.dto.InterviewResponseDto;
+import com.seoridam.rehearserver.repository.InterviewRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class InterviewService {
+	private final InterviewRepository interviewRepository;
+
+	// 인터뷰 하나 조회
+	@Transactional(readOnly = true)
+	public InterviewResponseDto getInterview(Long id) {
+
+		Optional<Interview> found = interviewRepository.findById(id);
+		Interview interview = found.orElseThrow(RuntimeException::new);
+
+		List<Tag> tagList = interview.getTagList();
+		List<String> subcategory_names = tagList.stream().map(tag -> tag.getSubCategory().getName()).collect(Collectors.toList());
+
+		return InterviewResponseDto.builder()
+			.id(interview.getId())
+			.createDate(interview.getCreateDate())
+			.body_text(interview.getBody_text())
+			.intro_text(interview.getIntro_text())
+			.sub_title(interview.getSub_title())
+			.photo_url(interview.getPhoto_url())
+			.subcategory_names(subcategory_names)
+			.view(interview.getView())
+			.video_url(interview.getVideo_url())
+			.title(interview.getTitle()).build();
+	}
+
+	//인터뷰 리스트 목록 조회
+	@Transactional(readOnly = true)
+	public Page<InterviewListDto> getInterviewList(PageRequest pageRequest){
+		Page<Interview> interviewList = interviewRepository.findAll(pageRequest);
+
+		List<InterviewListDto> interviewListDtos =
+			interviewList.stream().map(interview -> {
+				//태그 이름만 모아서 리스트 생성
+				List<Tag> tagList = interview.getTagList();
+				List<String> subcategory_names = tagList.stream().map(tag -> tag.getSubCategory().getName()).collect(Collectors.toList());
+				//DTO 반환
+				return InterviewListDto.builder()
+					.id(interview.getId())
+					.createDate(interview.getCreateDate())
+					.title(interview.getTitle())
+					.intro_text(interview.getIntro_text())
+					.photo_url(interview.getPhoto_url())
+					.view(interview.getView())
+					.subcategory_names(subcategory_names)
+					.build();
+			}).collect(Collectors.toList());
+
+		return new PageImpl<>(interviewListDtos);
+	}
+
+}

--- a/src/main/java/com/seoridam/rehearserver/service/InterviewService.java
+++ b/src/main/java/com/seoridam/rehearserver/service/InterviewService.java
@@ -36,7 +36,6 @@ public class InterviewService {
 		List<String> subcategory_names = tagList.stream().map(tag -> tag.getSubCategory().getName()).collect(Collectors.toList());
 
 		return InterviewResponseDto.builder()
-			.id(interview.getId())
 			.createDate(interview.getCreateDate())
 			.body_text(interview.getBodyText())
 			.intro_text(interview.getIntroText())


### PR DESCRIPTION
인터뷰 게시글 내용 조회
  - uri에 입력받은 인터뷰의 id값을 사용하여 조회
  - 연관된 subcategory의 이름을 태그로서 불러옴
인터뷰 리스트 목록 조회 (+ 페이징 기능)
  - 전체 인터뷰 리스트를 페이지/사이즈 별로 불러옴
  - 연관된 subcategory의 이름을 태그로서 불러옴